### PR TITLE
Authenticate token on certain path patterns

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -483,8 +483,15 @@ func (c *AgentCommand) Run(args []string) int {
 
 		var proxyVaultToken = !config.Cache.ForceAutoAuthToken
 
+		var authPathPatterns []string = nil
+		var tokenSecret string
+		if config.TokenConfig != nil && config.TokenConfig.EnableTokenAuth {
+			authPathPatterns = config.TokenConfig.AuthPathPatterns
+			tokenSecret = config.TokenConfig.Secret
+		}
+
 		// Create the request handler
-		cacheHandler := cache.Handler(ctx, cacheLogger, leaseCache, inmemSink, proxyVaultToken)
+		cacheHandler := cache.Handler(ctx, cacheLogger, leaseCache, inmemSink, proxyVaultToken, tokenSecret, authPathPatterns)
 
 		var listeners []net.Listener
 		for i, lnConfig := range config.Listeners {

--- a/command/agent/cache/auth.go
+++ b/command/agent/cache/auth.go
@@ -1,0 +1,67 @@
+package cache
+
+import (
+	"net/http"
+	"strings"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/command/agent/config"
+	"github.com/hashicorp/vault/sdk/helper/consts"
+)
+
+func authenticateToken(r *http.Request, tokenSecret string, patterns []string, logger hclog.Logger) bool {
+	token := r.Header.Get(consts.RequestHeaderVaultAgentToken)
+	identifier, match := extractIdentifier(r.URL.Path, patterns, logger)
+	if match && identifier != "" {
+		if token == "" {
+			return false
+		}
+		if token != config.IdentityToken(tokenSecret, identifier) {
+			return false
+		}
+	}
+	r.Header.Del(consts.RequestHeaderVaultAgentToken)
+	return true
+}
+
+func extractIdentifier(path string, patterns []string, logger hclog.Logger) (rv string, match bool) {
+	for _, p := range patterns {
+		p = strings.Trim(p, "/")
+		path = strings.Trim(path, "/")
+		patternFragments := strings.Split(p, "/")
+		pathFragments := strings.Split(path, "/")
+		rv, match = matchPatterns(pathFragments, patternFragments, logger)
+		if match {
+			return
+		}
+	}
+	return
+}
+
+func matchPatterns(values, patterns []string, logger hclog.Logger) (rv string, match bool) {
+	if len(values) != len(patterns) {
+		return
+	}
+	match = true
+	for i := 0; i < len(patterns); i++ {
+		if patterns[i] == ":identifier" {
+			if rv != "" {
+				logger.Error("Error! A pattern should have only one :identifier. Pattern: " + strings.Join(patterns, "/"))
+				return "", false
+			}
+			rv = values[i]
+		} else if patterns[i] != values[i] {
+			return "", false
+		}
+	}
+	return
+}
+
+func contains(sArray []string, str string) bool {
+	for _, s := range sArray {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/command/agent/cache/auth_test.go
+++ b/command/agent/cache/auth_test.go
@@ -1,0 +1,101 @@
+package cache
+
+import (
+	"testing"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+)
+
+func extractIdentifierMatch(t *testing.T, identifier, path string, patterns []string) {
+	logger := logging.NewVaultLogger(hclog.Trace)
+	id, match := extractIdentifier(path, patterns, logger)
+	if id != identifier {
+		t.Error("Failed to extract identifier", "id", id)
+	}
+	if !match {
+		t.Error("Failed to extract identifier", "match", match)
+	}
+}
+
+func extractIdentifierNoMatch(t *testing.T, path string, patterns []string) {
+	logger := logging.NewVaultLogger(hclog.Trace)
+	id, match := extractIdentifier(path, patterns, logger)
+	if id != "" {
+		t.Error("Extract identifier should have not have identifier", "id", id)
+	}
+	if match {
+		t.Error("Extract identifier should have no match", "match", match)
+	}
+}
+
+func TestAuth_ExtractIdentifier(t *testing.T) {
+	extractIdentifierMatch(t, "hello", "/svc/ent/dev/hello", []string{"/svc/ent/dev/:identifier"})
+	extractIdentifierMatch(t, "hello", "/svc/ent/dev/hello/", []string{"/svc/ent/dev/:identifier"})
+	extractIdentifierMatch(t, "hello", "/svc/ent/dev/hello/", []string{"/svc/ent/dev/:identifier/"})
+	extractIdentifierMatch(t, "hello", "/svc/ent/dev/hello", []string{"/svc/ent/dev/:identifier/"})
+	extractIdentifierMatch(t, "hello", "/svc/ent/dev/hello", []string{"svc/ent/dev/:identifier"})
+	extractIdentifierMatch(t, "hello", "svc/ent/dev/hello", []string{"svc/ent/dev/:identifier"})
+	extractIdentifierMatch(t, "hello2", "/svc/ent/dev/hello2", []string{"/svc/ent/dev/:identifier"})
+
+	extractIdentifierMatch(t, "ent", "svc/ent/dev/hello", []string{"svc/:identifier/dev/hello"})
+	extractIdentifierMatch(t, "svc", "svc/ent/dev/hello", []string{":identifier/ent/dev/hello"})
+
+	extractIdentifierMatch(t, "hello", "/svc/ent/qas/hello", []string{"/svc/ent/prd/:identifier", "/svc/ent/qas/:identifier"})
+	extractIdentifierMatch(t, "hello", "/svc/ent/qas/hello", []string{"/svc/ent/qas/:identifier", "/svc/ent/qas/:identifier"})
+
+	extractIdentifierMatch(t, "", "/svc", []string{"/svc"})
+
+	extractIdentifierNoMatch(t, "/svc1/ent/dev/hello", []string{"/svc/ent/dev/:identifier"})
+	extractIdentifierNoMatch(t, "/svc/ent/dev/hello/1", []string{"/svc/ent/dev/:identifier"})
+	extractIdentifierNoMatch(t, "/svc/ent/dev/", []string{"/svc/ent/dev/:identifier"})
+	extractIdentifierNoMatch(t, "/svc/ent/dev", []string{"/svc/ent/dev/:identifier"})
+
+	extractIdentifierNoMatch(t, "/svc/ent1/dev/hello", []string{"/svc/ent/dev/:identifier"})
+	extractIdentifierNoMatch(t, "/svc/ent/dev1/hello", []string{"/svc/ent/dev/:identifier"})
+
+	extractIdentifierNoMatch(t, "/svc/ent/dev/hello", []string{"/svc/ent/dev/identifier"})
+
+	extractIdentifierNoMatch(t, "/svc/ent/stg/hello", []string{"/svc/ent/prd/:identifier", "/svc/ent/dev/:identifier"})
+
+	extractIdentifierNoMatch(t, "svc/ent/dev/hello/aloha", []string{"svc/ent/dev/:identifier/:identifier"})
+	extractIdentifierNoMatch(t, "svc/ent/dev/hello/aloha", []string{"svc/:identifier/:identifier/:identifier/:identifier"})
+}
+
+func matchPatternsPass(t *testing.T, identity string, values, patterns []string) {
+	logger := logging.NewVaultLogger(hclog.Trace)
+	id, match := matchPatterns(values, patterns, logger)
+	if id != identity {
+		t.Error("Failed to match patterns", "id", id)
+	}
+	if !match {
+		t.Error("Failed to match patterns", "match", match)
+	}
+}
+
+func matchPatternsFail(t *testing.T, values, patterns []string) {
+	logger := logging.NewVaultLogger(hclog.Trace)
+	id, match := matchPatterns(values, patterns, logger)
+	if id != "" {
+		t.Error("Failed to match patterns", "id", id)
+	}
+	if match {
+		t.Error("Failed to match patterns", "match", match)
+	}
+}
+
+func TestAuth_MatchPatterns_Pass(t *testing.T) {
+	values := []string{"svc", "ent", "dev", "hello"}
+	patterns := []string{"svc", "ent", "dev", ":identifier"}
+	matchPatternsPass(t, "hello", values, patterns)
+
+	values = []string{"svc", "ent", "dev", "hello"}
+	patterns = []string{"svc", "ent", "dev", ":identifier"}
+	matchPatternsPass(t, "hello", values, patterns)
+}
+
+func TestAuth_MatchPatterns_Fail(t *testing.T) {
+	values := []string{"svc", "ent", "dev", "hello"}
+	patterns := []string{"svc", "ent", "qas", ":identifier"}
+	matchPatternsFail(t, values, patterns)
+}

--- a/command/agent/cache/cache_test.go
+++ b/command/agent/cache/cache_test.go
@@ -152,7 +152,7 @@ func setupClusterAndAgentCommon(ctx context.Context, t *testing.T, coreConfig *v
 	mux := http.NewServeMux()
 	mux.Handle("/agent/v1/cache-clear", leaseCache.HandleCacheClear(ctx))
 
-	mux.Handle("/", Handler(ctx, cacheLogger, leaseCache, nil, true))
+	mux.Handle("/", Handler(ctx, cacheLogger, leaseCache, nil, true, "", nil))
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
@@ -243,7 +243,7 @@ func TestCache_AutoAuthTokenStripping(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle(consts.AgentPathCacheClear, leaseCache.HandleCacheClear(ctx))
 
-	mux.Handle("/", Handler(ctx, cacheLogger, leaseCache, mock.NewSink("testid"), true))
+	mux.Handle("/", Handler(ctx, cacheLogger, leaseCache, mock.NewSink("testid"), true, "", nil))
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
@@ -308,7 +308,7 @@ func TestCache_AutoAuthClientTokenProxyStripping(t *testing.T) {
 	mux := http.NewServeMux()
 	//mux.Handle(consts.AgentPathCacheClear, leaseCache.HandleCacheClear(ctx))
 
-	mux.Handle("/", Handler(ctx, cacheLogger, leaseCache, mock.NewSink(realToken), false))
+	mux.Handle("/", Handler(ctx, cacheLogger, leaseCache, mock.NewSink(realToken), false, "", nil))
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,

--- a/command/agent/cache_end_to_end_test.go
+++ b/command/agent/cache_end_to_end_test.go
@@ -298,7 +298,7 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 	mux.Handle(consts.AgentPathCacheClear, leaseCache.HandleCacheClear(ctx))
 
 	// Passing a non-nil inmemsink tells the agent to use the auto-auth token
-	mux.Handle("/", cache.Handler(ctx, cacheLogger, leaseCache, inmemSink, true))
+	mux.Handle("/", cache.Handler(ctx, cacheLogger, leaseCache, inmemSink, true, "", nil))
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -84,7 +84,9 @@ type Sink struct {
 }
 
 type TokenConfig struct {
-	Secret string `hcl:"secret"`
+	Secret           string   `hcl:"secret"`
+	EnableTokenAuth  bool     `hcl:"enable_token_auth"`
+	AuthPathPatterns []string `hcl:"auth_path_patterns"`
 }
 
 func NewConfig() *Config {

--- a/sdk/helper/consts/consts.go
+++ b/sdk/helper/consts/consts.go
@@ -32,4 +32,6 @@ const (
 	// ReplicationResolverALPN is the negotiated protocol used for
 	// resolving replicaiton addresses
 	ReplicationResolverALPN = "replication_resolver_v1"
+
+	RequestHeaderVaultAgentToken = "X-Vault-Agent-Token"
 )


### PR DESCRIPTION
The instance level secret, like: service/enterprise/dev/xxx.xxxxx.com can only be accessed with a token generated with the same "xxx.xxxxx.com" text. So we can define pattern like: "service/enterprise/<dev,qas>/:identifier", and such pattern of URL will be authenticated with the token.

- [x] @johnny-lai 
- [x] @abdollar 