### PR TITLE
CD-219068 production: Add static secret cache

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -488,6 +488,10 @@ func (c *AgentCommand) Run(args []string) int {
 		var authPathPatterns []string = nil
 		var tokenSecret string
 		if config.TokenConfig != nil && config.TokenConfig.EnableTokenAuth {
+			if s, valid := config.TokenConfig.ValidatePatterns(); !valid {
+				c.UI.Error(fmt.Sprintf("Invalid token_config - auth_path_patterns in the config file. Only one ':identifier' per pattern is allowed: '%s'", s))
+				return 1
+			}
 			authPathPatterns = config.TokenConfig.AuthPathPatterns
 			tokenSecret = config.TokenConfig.Secret
 		}

--- a/command/agent.go
+++ b/command/agent.go
@@ -459,6 +459,8 @@ func (c *AgentCommand) Run(args []string) int {
 			BaseContext: ctx,
 			Proxier:     apiProxy,
 			Logger:      cacheLogger.Named("leasecache"),
+			//Multiply minutes by 60 so that we can support a fraction of a minute
+			StaticSecretDuration: time.Duration(float64(config.Cache.StaticSecretDurationInMinutes)*60) * time.Second,
 		})
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error creating lease cache: %v", err))

--- a/command/agent/cache/auth_test.go
+++ b/command/agent/cache/auth_test.go
@@ -2,14 +2,10 @@ package cache
 
 import (
 	"testing"
-
-	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 )
 
 func extractIdentifierMatch(t *testing.T, identifier, path string, patterns []string) {
-	logger := logging.NewVaultLogger(hclog.Trace)
-	id, match := extractIdentifier(path, patterns, logger)
+	id, match := extractIdentifier(path, patterns)
 	if id != identifier {
 		t.Error("Failed to extract identifier", "id", id)
 	}
@@ -19,8 +15,7 @@ func extractIdentifierMatch(t *testing.T, identifier, path string, patterns []st
 }
 
 func extractIdentifierNoMatch(t *testing.T, path string, patterns []string) {
-	logger := logging.NewVaultLogger(hclog.Trace)
-	id, match := extractIdentifier(path, patterns, logger)
+	id, match := extractIdentifier(path, patterns)
 	if id != "" {
 		t.Error("Extract identifier should have not have identifier", "id", id)
 	}
@@ -63,8 +58,7 @@ func TestAuth_ExtractIdentifier(t *testing.T) {
 }
 
 func matchPatternsPass(t *testing.T, identity string, values, patterns []string) {
-	logger := logging.NewVaultLogger(hclog.Trace)
-	id, match := matchPatterns(values, patterns, logger)
+	id, match := matchPatterns(values, patterns)
 	if id != identity {
 		t.Error("Failed to match patterns", "id", id)
 	}
@@ -74,8 +68,7 @@ func matchPatternsPass(t *testing.T, identity string, values, patterns []string)
 }
 
 func matchPatternsFail(t *testing.T, values, patterns []string) {
-	logger := logging.NewVaultLogger(hclog.Trace)
-	id, match := matchPatterns(values, patterns, logger)
+	id, match := matchPatterns(values, patterns)
 	if id != "" {
 		t.Error("Failed to match patterns", "id", id)
 	}

--- a/command/agent/cache/handler.go
+++ b/command/agent/cache/handler.go
@@ -24,7 +24,7 @@ func Handler(ctx context.Context, logger hclog.Logger, proxier Proxier, inmemSin
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("received request", "method", r.Method, "path", r.URL.Path)
 
-		if len(authPatterns) > 0 && !authenticateToken(r, tokenSecret, authPatterns, logger) {
+		if len(authPatterns) > 0 && !authenticateToken(r, tokenSecret, authPatterns) {
 			logger.Info("unauthorized request with token", "path", r.URL.Path)
 			w.WriteHeader(http.StatusForbidden)
 			return

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -45,9 +45,10 @@ type Vault struct {
 
 // Cache contains any configuration needed for Cache mode
 type Cache struct {
-	UseAutoAuthTokenRaw interface{} `hcl:"use_auto_auth_token"`
-	UseAutoAuthToken    bool        `hcl:"-"`
-	ForceAutoAuthToken  bool        `hcl:"-"`
+	UseAutoAuthTokenRaw           interface{} `hcl:"use_auto_auth_token"`
+	UseAutoAuthToken              bool        `hcl:"-"`
+	ForceAutoAuthToken            bool        `hcl:"-"`
+	StaticSecretDurationInMinutes float64     `hcl:"static_secret_duration_in_minutes"`
 }
 
 // AutoAuth is the configured authentication method and sinks

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/internalshared/configutil"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/mitchellh/mapstructure"
 )
@@ -88,6 +89,25 @@ type TokenConfig struct {
 	Secret           string   `hcl:"secret"`
 	EnableTokenAuth  bool     `hcl:"enable_token_auth"`
 	AuthPathPatterns []string `hcl:"auth_path_patterns"`
+}
+
+func (tc *TokenConfig) ValidatePatterns() (string, bool) {
+	for _, p := range tc.AuthPathPatterns {
+		if !tc.validatePattern(p) {
+			return p, false
+		}
+	}
+	return "", true
+}
+
+func (tc *TokenConfig) validatePattern(p string) bool {
+	count := 0
+	for _, seg := range strings.Split(p, "/") {
+		if seg == consts.AuthPatternIdentifier {
+			count++
+		}
+	}
+	return count == 1
 }
 
 func NewConfig() *Config {

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -642,3 +642,37 @@ func TestLoadConfigFile_Template_NoSinks(t *testing.T) {
 		})
 	}
 }
+
+func TestTokenConfig_ValidatePatterns(t *testing.T) {
+	expectAuthPatternsValid(t, []string{"a/b/c/:identifier"})
+	expectAuthPatternsValid(t, []string{":identifier"})
+	expectAuthPatternsValid(t, []string{":identifier/a"})
+	expectAuthPatternsValid(t, []string{"a/b/:identifier/", "a/:identifier/b"})
+
+	expectAuthPatternsInvalid(t, []string{"a/b/c/:identifierer"})
+	expectAuthPatternsInvalid(t, []string{":identifier/b/c/:identifier"})
+	expectAuthPatternsInvalid(t, []string{":identifier/b/c/:identifier/:identifier"})
+	expectAuthPatternsInvalid(t, []string{"a/b/c", "d/e/f"})
+}
+
+func expectAuthPatternsValid(t *testing.T, patterns []string) {
+	tc := &TokenConfig{AuthPathPatterns: patterns}
+	p, valid := tc.ValidatePatterns()
+	if !valid {
+		t.Fatalf("Expected patterns %s to be valid", patterns)
+	}
+	if p != "" {
+		t.Fatalf("Expected valid patterns %s not to return an invalid pattern: %s", patterns, p)
+	}
+}
+
+func expectAuthPatternsInvalid(t *testing.T, patterns []string) {
+	tc := &TokenConfig{AuthPathPatterns: patterns}
+	p, valid := tc.ValidatePatterns()
+	if valid {
+		t.Fatalf("Expected patterns %s to be invalid", patterns)
+	}
+	if p == "" {
+		t.Fatalf("Expected invalid patterns %s return an invalid pattern", patterns)
+	}
+}

--- a/sdk/helper/consts/consts.go
+++ b/sdk/helper/consts/consts.go
@@ -34,4 +34,5 @@ const (
 	ReplicationResolverALPN = "replication_resolver_v1"
 
 	RequestHeaderVaultAgentToken = "X-Vault-Agent-Token"
+	AuthPatternIdentifier        = ":identifier"
 )


### PR DESCRIPTION
A static secret's response is a non-renewable secret with no lease ID or lease duration. To cache static secret, we bypass the renewable check and use the request's URL path as the lease ID. We added a new config for static secret cache duration. Once a static secret is created, a watcher is created for it and starts in its own goroutine. When the static secret cache duration is up, the watcher notifies the goroutine which will evict the secret's cache if Vault server is healthy. If Vault server is down at this moment, it won't evict the cache and start the watcher again.

The second commit refactored some auth code from previous PR, to remove the logging from the checking pattern function. Instead we check the patterns in the main program and exit if the patterns are invalid.

- [x] @johnny-lai 
- [x] @abdollar 