### PR TITLE
Build binary with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+pkg
+bin
+dist

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ EXTERNAL_TOOLS=\
 	github.com/client9/misspell/cmd/misspell
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v pb.go | grep -v vendor)
 
+ifdef BUILD_NUMBER
+	BUILD_IDENTIFIER = _${BUILD_NUMBER}
+endif
 
 GO_VERSION_MIN=1.14.7
 GO_CMD?=go
@@ -53,12 +56,23 @@ dev-dynamic-mem: BUILD_TAGS+=memprofiler
 dev-dynamic-mem: dev-dynamic
 
 # Creates a Docker image by adding the compiled linux/amd64 binary found in ./bin.
-# The resulting image is tagged "vault:dev". 
+# The resulting image is tagged "vault:dev".
 docker-dev: prep
 	docker build -f scripts/docker/Dockerfile -t vault:dev .
 
 docker-dev-ui: prep
 	docker build -f scripts/docker/Dockerfile.ui -t vault:dev-ui .
+
+docker.build: clean prep
+	docker build -f scripts/docker/Dockerfile-builder -t vault_bin${BUILD_IDENTIFIER} .
+	docker create -it --name tocopy-vault${BUILD_IDENTIFIER} vault_bin${BUILD_IDENTIFIER} sh
+	docker cp tocopy-vault${BUILD_IDENTIFIER}:go/src/vault/pkg $(realpath .)/dist/
+	docker cp tocopy-vault${BUILD_IDENTIFIER}:go/src/vault/bin $(realpath .)/dist/
+	docker rm -f tocopy-vault${BUILD_IDENTIFIER}
+	docker rmi -f vault_bin${BUILD_IDENTIFIER}
+
+clean:
+	rm -rf bin pkg dist
 
 # test runs the unit tests and vets the code
 test: prep

--- a/scripts/docker/Dockerfile-builder
+++ b/scripts/docker/Dockerfile-builder
@@ -1,0 +1,15 @@
+ARG VERSION=1.15-alpine
+
+FROM golang:${VERSION}
+
+ARG CGO_ENABLED=0
+ARG BUILD_TAGS
+
+RUN apk add --update nodejs-npm yarn zip make git bash
+
+WORKDIR /go/src/vault
+COPY . .
+
+RUN make bootstrap
+RUN make static-dist
+RUN XC_OSARCH="linux/amd64 darwin/amd64" make bin

--- a/ui/package.json
+++ b/ui/package.json
@@ -172,7 +172,7 @@
     "serialize-javascript": "^2.1.1"
   },
   "engines": {
-    "node": " >= 10.* <11"
+    "node": " >= 10.*"
   },
   "private": true,
   "ember-addon": {


### PR DESCRIPTION
Had to take out the restriction of nodejs<11 for the asset to build, which worked fine. And we actually don't use the assets since we are only using the Vault agent.

- [x] @johnny-lai 