### PR TITLE
Make OSARCH option configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ EXTERNAL_TOOLS=\
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v pb.go | grep -v vendor)
 DIST_DIR=$(realpath .)/dist
 
+ifdef XC_OSARCH
+	DOCKER_BUILD_ARGS = --build-arg XC_OSARCH="${XC_OSARCH}"
+endif
+
 ifdef BUILD_NUMBER
 	BUILD_IDENTIFIER = _${BUILD_NUMBER}
 endif
@@ -65,7 +69,7 @@ docker-dev-ui: prep
 	docker build -f scripts/docker/Dockerfile.ui -t vault:dev-ui .
 
 docker.build: clean
-	docker build -f scripts/docker/Dockerfile-builder -t vault_bin${BUILD_IDENTIFIER} .
+	docker build -f scripts/docker/Dockerfile-builder -t vault_bin${BUILD_IDENTIFIER} ${DOCKER_BUILD_ARGS} .
 	docker create -it --name tocopy-vault${BUILD_IDENTIFIER} vault_bin${BUILD_IDENTIFIER} sh
 	mkdir -p ${DIST_DIR}
 	docker cp tocopy-vault${BUILD_IDENTIFIER}:go/src/vault/pkg ${DIST_DIR}

--- a/scripts/docker/Dockerfile-builder
+++ b/scripts/docker/Dockerfile-builder
@@ -4,6 +4,7 @@ FROM golang:${VERSION}
 
 ARG CGO_ENABLED=0
 ARG BUILD_TAGS
+ARG XC_OSARCH="linux/amd64 darwin/amd64"
 
 RUN apk add --update nodejs-npm yarn zip make git bash
 
@@ -12,4 +13,4 @@ COPY . .
 
 RUN make bootstrap
 RUN make static-dist
-RUN XC_OSARCH="linux/amd64 darwin/amd64" make bin
+RUN XC_OSARCH="${XC_OSARCH}" make bin


### PR DESCRIPTION
Let the build tool specify what OS architecture to build binaries for.

- [ ] @johnny-lai  