### PR TITLE
JZ-90992 Fix vault agent accumulating memory by

### DIFF
--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -84,7 +84,7 @@ type LifetimeWatcher struct {
 	doneCh               chan error
 	renewCh              chan *RenewOutput
 	renewBehavior        RenewBehavior
-	staticSecretDuration time.Duration
+	StaticSecretDuration time.Duration
 	staticResetCh        chan error
 
 	stopped bool
@@ -164,7 +164,7 @@ func (c *Client) NewLifetimeWatcher(i *LifetimeWatcherInput) (*LifetimeWatcher, 
 		doneCh:               make(chan error, 1),
 		renewCh:              make(chan *RenewOutput, renewBuffer),
 		renewBehavior:        i.RenewBehavior,
-		staticSecretDuration: i.StaticSecretDuration,
+		StaticSecretDuration: i.StaticSecretDuration,
 		staticResetCh:        make(chan error, 1),
 
 		stopped: false,
@@ -248,7 +248,7 @@ func (r *LifetimeWatcher) doStaticCheck() error {
 		select {
 		case <-r.stopCh:
 			return nil
-		case <-time.After(r.staticSecretDuration):
+		case <-time.After(r.StaticSecretDuration):
 			return nil
 		}
 	}

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -46,10 +46,12 @@ type Vault struct {
 
 // Cache contains any configuration needed for Cache mode
 type Cache struct {
-	UseAutoAuthTokenRaw           interface{} `hcl:"use_auto_auth_token"`
-	UseAutoAuthToken              bool        `hcl:"-"`
-	ForceAutoAuthToken            bool        `hcl:"-"`
-	StaticSecretDurationInMinutes float64     `hcl:"static_secret_duration_in_minutes"`
+	UseAutoAuthTokenRaw                interface{} `hcl:"use_auto_auth_token"`
+	UseAutoAuthToken                   bool        `hcl:"-"`
+	ForceAutoAuthToken                 bool        `hcl:"-"`
+	StaticSecretDurationInMinutes      float64     `hcl:"static_secret_duration_in_minutes"`
+	StaticSecretRetryDurationInMinutes *float64    `hcl:"static_secret_retry_duration_in_minutes"`
+	StaticSecretMaxRetryCount          *float64    `hcl:"static_secret_max_retry_count"`
 }
 
 // AutoAuth is the configured authentication method and sinks

--- a/sdk/version/version_base.go
+++ b/sdk/version/version_base.go
@@ -8,7 +8,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.5.0"
+	Version           = "1.5.1"
 	VersionPrerelease = ""
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
https://coupadev.atlassian.net/browse/JZ-90992

(1) making static secret cache key stable;
(2) when health checking Vault secret for cache eviction, get the access token from the sink instead of using the one from the cached request.

**A major change** to limit how long to keep health checking for cache eviction. The "static_secret_retry_duration_in_minutes" (default 1 hour) and
"static_secret_max_retry_count" (default 48) in the config define the health check frequency up to how many times. The default values make it
check every hour for up to 2 days. Meaning that if Vault sever ever goes down, we have 48 hours to get it back. After 48 hours, the agent will
evict the cache no matter what. This is so that we don't have a goroutine and cache item that stays forever.

One fix to handle deleted secrets. When health check the secret and receive 404, it means the secret is removed, so go ahead and remove the cached secret.

In addition, made a function to check for static secret. This way the Vault agent will not try to use the static cache for dynamic secrets.

- [ ] @johnny-lai 
- [x] @abdulchaudhrycoupa 

Tested locally.

## Generated Reviewers

<details>
  <summary><em>:warning: Do not modify anything in this section! :warning:</em></summary>
  <em>The content in this section is managed automatically, and any manual changes to it will be ignored and overwritten the next time the code review status is refreshed! View <a href="https://cody.coupa.engineering/repos/coupa/vault/pull/6">this PR</a> on Cody to see the current code review status.</em>
</details>

